### PR TITLE
save config file for unwrapped model during trainer.save

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -308,6 +308,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
     def save(self, directory: Optional[str] = None, **kwargs):
         """Creates a checkpoint of the optimizer, scheduler and model"""
         self.accelerator.save_state(directory or self.config.train.checkpoint_dir, **kwargs)
+        self.accelerator.unwrap_model(self.model).config.save_pretrained(directory or self.config.train.checkpoint_dir)
 
     def load(self, directory: Optional[str] = None, **kwargs):
         """Load checkpoint of optimizer, scheduler and a model"""

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -12,15 +12,119 @@ from trlx.utils import set_seed
 from trlx.utils.loading import get_pipeline, get_trainer
 
 
-def train(  # noqa: C901
+def setup_trainer(
     model_path: Optional[str] = None,
-    reward_fn: Optional[Callable[[List[str], List[str], List[str]], List[float]]] = None,
+    reward_fn: Optional[
+        Callable[[List[str], List[str], List[str]], List[float]]
+    ] = None,
     dataset: Optional[Iterable[Tuple[str, float]]] = None,
     samples: Optional[List[str]] = None,
     rewards: Optional[List[float]] = None,
     prompts: Optional[List[str]] = None,
     eval_prompts: Optional[List[str]] = None,
-    metric_fn: Optional[Callable[[List[str], List[str], List[str]], Dict[str, List[float]]]] = None,
+    metric_fn: Optional[
+        Callable[[List[str], List[str], List[str]], Dict[str, List[float]]]
+    ] = None,
+    config: Optional[TRLConfig] = None,
+    stop_sequences: Optional[List[str]] = [],
+):
+    if config is None:
+        warnings.warn(
+            "Passing the `config` argument implicitly is depreciated, use or"
+            "adapt some from `trlx/data/default_configs.py` instead"
+        )
+        if reward_fn:
+            config = default_ppo_config()
+        elif rewards:
+            config = default_ilql_config()
+        else:
+            config = default_sft_config()
+
+    set_seed(config.train.seed)
+
+    if dataset:
+        warnings.warn(
+            "the `dataset` argument is being depreciated, split it into `samples` and `rewards` instead"
+        )
+        samples, rewards = dataset
+
+    if model_path:
+        config.model.model_path = model_path
+
+    trainer = get_trainer(config.train.trainer)(
+        config=config,
+        reward_fn=reward_fn,
+        metric_fn=metric_fn,
+        stop_sequences=stop_sequences,
+        **config.train.trainer_kwargs,
+    )
+
+    batch_size = config.train.batch_size * int(os.environ.get("WORLD_SIZE", 1))
+    max_prompt_length = (
+        config.train.seq_length - config.method.gen_kwargs["max_new_tokens"]
+    )
+
+    # Online training against a reward function (e.g. PPO)
+    if reward_fn:
+        prompts = prompts or [trainer.tokenizer.bos_token] * batch_size
+
+        if eval_prompts is None:
+            eval_prompts = prompts[:batch_size]
+
+        pipeline = get_pipeline(config.train.pipeline)(
+            prompts,
+            max_prompt_length,
+            trainer.tokenizer,
+            add_special_tokens=config.model.model_arch_type == "seq2seq",
+        )
+        trainer.add_prompt_pipeline(pipeline)
+
+        if eval_prompts is None:
+            eval_prompts = prompts[:batch_size]
+
+        trainer.make_experience(config.method.num_rollouts)
+
+    # Offline training from the collected samples (e.g. SFT, ILQL)
+    elif samples:
+        if rewards is not None:
+            if len(samples) != len(rewards):
+                raise ValueError(
+                    f"Number of samples {len(samples)} should match the number of rewards {len(rewards)}"
+                )
+
+        if eval_prompts is None:
+            eval_prompts = [trainer.tokenizer.bos_token] * batch_size
+
+        if rewards is not None:
+            trainer.make_experience(samples, rewards, config.train.seq_length)
+        else:
+            trainer.make_experience(samples, config.train.seq_length)
+    else:
+        raise ValueError("Either `samples` or `reward_fn` should be given for training")
+
+    eval_pipeline = get_pipeline(config.train.pipeline)(
+        eval_prompts,
+        max_prompt_length,
+        trainer.tokenizer,
+        add_special_tokens=config.model.model_arch_type == "seq2seq",
+    )
+    trainer.add_eval_pipeline(eval_pipeline)
+    return trainer
+
+
+def train(  # noqa: C901
+    model_path: Optional[str] = None,
+    reward_fn: Optional[
+        Callable[[List[str], List[str], List[str]], List[float]]
+    ] = None,
+    dataset: Optional[Iterable[Tuple[str, float]]] = None,
+    samples: Optional[List[str]] = None,
+    rewards: Optional[List[float]] = None,
+    prompts: Optional[List[str]] = None,
+    eval_prompts: Optional[List[str]] = None,
+    metric_fn: Optional[
+        Callable[[List[str], List[str], List[str]], Dict[str, List[float]]]
+    ] = None,
     config: Optional[TRLConfig] = None,
     stop_sequences: Optional[List[str]] = [],
 ):
@@ -55,75 +159,18 @@ def train(  # noqa: C901
             String sequences to trim generations (both for generating of experience and evaluation) up to its
             encounter in them. Generations will not contain them and also will also be right-stripped
     """
-    if config is None:
-        warnings.warn(
-            "Passing the `config` argument implicitly is depreciated, use or"
-            "adapt some from `trlx/data/default_configs.py` instead"
-        )
-        if reward_fn:
-            config = default_ppo_config()
-        elif rewards:
-            config = default_ilql_config()
-        else:
-            config = default_sft_config()
-
-    set_seed(config.train.seed)
-
-    if dataset:
-        warnings.warn("the `dataset` argument is being depreciated, split it into `samples` and `rewards` instead")
-        samples, rewards = dataset
-
-    if model_path:
-        config.model.model_path = model_path
-
-    trainer = get_trainer(config.train.trainer)(
-        config=config,
+    trainer = setup_trainer(
+        model_path=model_path,
         reward_fn=reward_fn,
+        dataset=dataset,
+        samples=samples,
+        rewards=rewards,
+        prompts=prompts,
+        eval_prompts=eval_prompts,
         metric_fn=metric_fn,
+        config=config,
         stop_sequences=stop_sequences,
-        **config.train.trainer_kwargs,
     )
-
-    batch_size = config.train.batch_size * int(os.environ.get("WORLD_SIZE", 1))
-    max_prompt_length = config.train.seq_length - config.method.gen_kwargs["max_new_tokens"]
-
-    # Online training against a reward function (e.g. PPO)
-    if reward_fn:
-        prompts = prompts or [trainer.tokenizer.bos_token] * batch_size
-
-        if eval_prompts is None:
-            eval_prompts = prompts[:batch_size]
-
-        pipeline = get_pipeline(config.train.pipeline)(
-            prompts, max_prompt_length, trainer.tokenizer, add_special_tokens=config.model.model_arch_type == "seq2seq"
-        )
-        trainer.add_prompt_pipeline(pipeline)
-
-        if eval_prompts is None:
-            eval_prompts = prompts[:batch_size]
-
-        trainer.make_experience(config.method.num_rollouts)
-
-    # Offline training from the collected samples (e.g. SFT, ILQL)
-    elif samples:
-        if rewards is not None:
-            if len(samples) != len(rewards):
-                raise ValueError(f"Number of samples {len(samples)} should match the number of rewards {len(rewards)}")
-
-        if eval_prompts is None:
-            eval_prompts = [trainer.tokenizer.bos_token] * batch_size
-
-        if rewards is not None:
-            trainer.make_experience(samples, rewards, config.train.seq_length)
-        else:
-            trainer.make_experience(samples, config.train.seq_length)
-    else:
-        raise ValueError("Either `samples` or `reward_fn` should be given for training")
-
-    eval_pipeline = get_pipeline(config.train.pipeline)(
-        eval_prompts, max_prompt_length, trainer.tokenizer, add_special_tokens=config.model.model_arch_type == "seq2seq"
-    )
-    trainer.add_eval_pipeline(eval_pipeline)
 
     trainer.learn()
     return trainer


### PR DESCRIPTION
- save a config.json along with the optimizer states in trainer.save()
- separate trainer setup from trainer.learn() in trlx.train() so we can load the saved state before resuming training

- assumes that trainer.learn() will pick up where the last training run left off